### PR TITLE
fix: revision API response deserialization 개선 및 HTTP 에러 로깅 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+.claude

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -128,8 +128,8 @@ impl RevisionVersion {
 #[derive(Deserialize, Debug, Clone)]
 pub struct Revision {
     #[serde(rename = "createTime")]
-    pub create_time: chrono::DateTime<chrono::Utc>,
-    pub version: RevisionVersion,
+    pub create_time: Option<chrono::DateTime<chrono::Utc>>,
+    pub version: Option<RevisionVersion>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
+use crate::cli::LoginArgs;
+
 /// Represents the main configuration for the application, stored in `~/.shelltide/config.json`.
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct AppConfig {
@@ -17,6 +19,46 @@ pub struct AppConfig {
     /// A map of release names to their details.
     #[serde(default)]
     pub releases: HashMap<String, Release>,
+}
+
+impl AppConfig {
+    pub fn get_credentials(&self) -> Result<&Credentials> {
+        self.credentials
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No credentials found. please run `shelltide login`"))
+    }
+    pub fn get_login_args(&self) -> Result<LoginArgs> {
+        Ok(LoginArgs {
+            url: self
+                .credentials
+                .as_ref()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("No credentials found. please run `shelltide login`")
+                })?
+                .url
+                .clone(),
+            service_account: self
+                .credentials
+                .as_ref()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("No credentials found. please run `shelltide login`")
+                })?
+                .service_account
+                .clone(),
+            service_key: self
+                .credentials
+                .as_ref()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("No credentials found. please run `shelltide login`")
+                })?
+                .service_key
+                .as_ref()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("No credentials found. please run `shelltide login`")
+                })?
+                .clone(),
+        })
+    }
 }
 
 /// Stores details for a single release.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, Commands};
 
+#[cfg(not(test))]
 use crate::api::clients::LiveApiClient;
 
 #[cfg(test)]
@@ -40,19 +41,22 @@ async fn main() -> Result<()> {
         Commands::Env(args) => {
             let mut client = get_client().await?;
             let app_config = config::load_config().await?;
-            client.login(&app_config.credentials.unwrap())?;
+            let credentials = app_config.get_credentials()?;
+            client.login(credentials)?;
             commands::env::handle_env_command(args.command, &client).await?;
         }
         Commands::Migrate(args) => {
             let mut client = get_client().await?;
             let app_config = config::load_config().await?;
-            client.login(&app_config.credentials.unwrap())?;
+            let credentials = app_config.get_credentials()?;
+            client.login(credentials)?;
             commands::migrate::handle_migrate_command(args, &client).await?;
         }
         Commands::Status => {
             let mut client = get_client().await?;
             let app_config = config::load_config().await?;
-            client.login(&app_config.credentials.unwrap())?;
+            let credentials = app_config.get_credentials()?;
+            client.login(credentials)?;
             commands::status::handle_status_command(&client).await?;
         }
         Commands::Completion(args) => {


### PR DESCRIPTION
- Revision 구조체의 createTime, version 필드를 Option으로 변경하여 API 응답 필드 누락 대응
- 모든 API 호출에 일관된 HTTP status code 및 response body 로깅 추가
- handle_response 헬퍼 함수 도입으로 에러 처리 표준화
- migrate.rs에서 Option 필드 처리 로직 수정