### PR TITLE
feat: migrate 명령어 간소화

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,14 @@ Reference environment: dev (latest issue: #245)
 
 ### 5. 마이그레이션
 
-소스에서 대상으로 마이그레이션을 적용합니다. 환경과 데이터베이스를 `<env-name>/<database>`로 지정하고, `--to`로 버전을 지정합니다.
+기본 소스 환경(default.source_env)에서 대상 환경으로 마이그레이션을 적용합니다. 소스 데이터베이스 이름과 대상을 `<env-name>/<database>` 형식으로 지정하고, `--to`로 버전을 지정합니다.
 
 ```sh
-# dev/mydb에서 staging/mydb로 특정 버전까지 마이그레이션
-shelltide migrate dev/mydb staging/mydb --to 244
+# source 환경의 mydb 데이터베이스를 staging 환경의 mydb로 특정 버전까지 마이그레이션
+shelltide migrate mydb staging/mydb --to 244
 
 # 사용 가능한 최신 버전으로 마이그레이션
-shelltide migrate dev/mydb prod/mydb --to LATEST
+shelltide migrate mydb prod/mydb --to LATEST
 ```
 명령어는 대기 중인 이슈에 대해 SQL을 검증하고, 오류가 없는 경우에만 진행합니다.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,8 +116,8 @@ impl std::str::FromStr for EnvDb {
 
 #[derive(Parser, Debug)]
 pub struct MigrateArgs {
-    /// Source as "<env>/<database>"
-    pub source: EnvDb,
+    /// Source database name
+    pub source_db: String,
     /// Target as "<env>/<database>"
     pub target: EnvDb,
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -11,8 +11,11 @@ pub async fn handle_status_command<T: BytebaseApi>(api_client: &mut T, args: Sta
         return Ok(());
     }
 
-    // Get default source environment for reference
-    let default_source_env = config.default_source_env.as_deref().unwrap_or("dev");
+    // Get default source environment for reference - must be configured
+    let default_source_env = config.default_source_env.as_deref()
+        .ok_or_else(|| anyhow::anyhow!(
+            "Configuration error: default.source_env not set. Please run: shelltide config set default.source_env <env-name>"
+        ))?;
     let default_env = config.environments.get(default_source_env)
         .ok_or_else(|| anyhow::anyhow!("Default source environment '{}' not found in config", default_source_env))?;
 


### PR DESCRIPTION
migrate 명령어에서 source 환경 인자 제거(default.source_env 설정을
  자동으로 사용)

resolves #6 